### PR TITLE
Fix broken builds

### DIFF
--- a/input_base_page.py
+++ b/input_base_page.py
@@ -227,7 +227,7 @@ class InputBasePage(Page):
         return self.selenium.is_visible(self._custom_dates_locator)
 
     def wait_for_datepicker_to_finish_animating(self):
-        self.selenium.wait_for_condition("selenium.browserbot.getCurrentWindow().document.getElementById('ui-datepicker-div').scrollHeight == 184", 10000)
+        self.selenium.wait_for_condition("selenium.browserbot.getCurrentWindow().document.getElementById('ui-datepicker-div').scrollWidth == 251", 10000)
 
     def click_start_date(self):
         """


### PR DESCRIPTION
Once we hit January the scrollHeight of the datepicker changed, which caused automated test failures. I have modified this to wait for the scrollWidth, which should be consistent. Please review and pull asap to fix broken test builds.
