### PR TITLE
Added Firefox 4.0b9 to the product versions list.

### DIFF
--- a/test_product_filter.py
+++ b/test_product_filter.py
@@ -52,7 +52,7 @@ import search_results_page
 class SearchFirefox(unittest.TestCase):
 
     _products = (
-        {"name": "firefox", "versions": ("4.0b8", "4.0b7", "4.0b6", "4.0b5", "4.0b4", "4.0b3", "4.0b2", "4.0b1")},
+        {"name": "firefox", "versions": ("4.0b9", "4.0b8", "4.0b7", "4.0b6", "4.0b5", "4.0b4", "4.0b3", "4.0b2", "4.0b1")},
         {"name": "mobile", "versions": ("4.0b3", "4.0b2", "4.0b1")}
     )
 


### PR DESCRIPTION
As Firefox 4.0 beta 9 is now appearing on the site we need this change to get the tests passing again. Please review and pull into the main test repository as soon as possible.
