### PR TITLE
Added Mobile 4.0b4 to the product versions list.

### DIFF
--- a/test_product_filter.py
+++ b/test_product_filter.py
@@ -53,7 +53,7 @@ class SearchFirefox(unittest.TestCase):
 
     _products = (
         {"name": "firefox", "versions": ("4.0b10", "4.0b9", "4.0b8", "4.0b7", "4.0b6", "4.0b5", "4.0b4", "4.0b3", "4.0b2", "4.0b1")},
-        {"name": "mobile", "versions": ("4.0b3", "4.0b2", "4.0b1")}
+        {"name": "mobile", "versions": ("4.0b4", "4.0b3", "4.0b2", "4.0b1")}
     )
 
     def setUp(self):


### PR DESCRIPTION
Once Mobile 4.0 beta 4 is released we will need this change to get the tests passing again. As soon as we notice the new version appearing on the site please test, review and pull into the main test repository.

Do not pull this change into the main repository before the new version is not appearing on the site as this would cause failures.
