### PR TITLE
Improve base page timeouts

### DIFF
--- a/input_base_page.py
+++ b/input_base_page.py
@@ -109,11 +109,8 @@ class InputBasePage(Page):
     _next_page_locator = "css=.pager .next"
 
     def __init__(self, selenium):
-        """Create a new instance of the class & get the page ready for testing."""
         self.selenium = selenium
-        self.selenium.open('/')
         self.selenium.window_maximize()
-        self.wait_for_element_present(self._search_box)
 
     @property
     def products(self):

--- a/test_search.py
+++ b/test_search.py
@@ -42,7 +42,8 @@
 from selenium import selenium
 from vars import ConnectionParameters
 import unittest
-from input_base_page import InputBasePage
+
+import feedback_page
 
 
 class TestSearch(unittest.TestCase):
@@ -60,17 +61,23 @@ class TestSearch(unittest.TestCase):
         '''
             Litmus 13847
         '''
-        inpbas = InputBasePage(self.selenium)
-        inpbas.search_for('')
-        self.assertTrue(0 < inpbas.message_count)
+        selenium = self.selenium
+        feedback_pg = feedback_page.FeedbackPage(selenium)
+
+        feedback_pg.go_to_feedback_page()
+        feedback_pg.search_for('')
+        self.assertTrue(0 < feedback_pg.message_count)
 
     def test_that_we_can_search_with_unicode(self):
         '''
             Litmus 13697
         '''
-        inpbas = InputBasePage(self.selenium)
-        inpbas.search_for(u"Tension et violence en C\xf4ted'Ivoire avant les r\xe9sultats")
-        self.assertTrue(0 < inpbas.message_count)
+        selenium = self.selenium
+        feedback_pg = feedback_page.FeedbackPage(selenium)
+
+        feedback_pg.go_to_feedback_page()
+        feedback_pg.search_for(u"Tension et violence en C\xf4ted'Ivoire avant les r\xe9sultats")
+        self.assertTrue(0 < feedback_pg.message_count)
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
This should reduce the amount of time it takes for tests to fail by removing the wait for the search box. Also, it removes an unnecessary additional page load. I needed to slightly rework the search tests for this.
