### PR TITLE
Removed Xfails for bugs and fixed the redirects

### DIFF
--- a/test_feedback_layout.py
+++ b/test_feedback_layout.py
@@ -94,7 +94,6 @@ class Test_Feedback_Layout:
 
         Assert.true(footer.is_language_dropdown_visible)
 
-    @xfail(reason="Bug 663862 - [stage] Landing page is missing components")
     def test_the_left_panel_layout(self, testsetup):
         """
         Litmus 13595 - input:Verify the layout of the left hand side section containing various

--- a/test_product_filter.py
+++ b/test_product_filter.py
@@ -160,7 +160,6 @@ class TestProductFilter:
             Assert.equal(sites_pg.product_from_url, product)
             Assert.equal(sites_pg.version_from_url, version)
 
-    @xfail(reason="Bug 662113 - Page does not update when selecting mobile in the product combobox")
     def test_sites_can_be_filtered_by_mobile_versions(self, testsetup):
         """
         This testcase covers # 15043 & 15044 in Litmus

--- a/test_redirects.py
+++ b/test_redirects.py
@@ -86,23 +86,23 @@ class TestRedirects:
 
     @pytest.mark.skip_selenium
     def test_feedback_search_without_locale_redirects_to_feedback_search_with_locale(self, testsetup):
-        self._check_redirect(testsetup, '/search?sentiment=happy', '/en-US/search?sentiment=happy')
+        self._check_redirect(testsetup, '/?sentiment=happy', '/en-US/?sentiment=happy')
 
     @pytest.mark.skip_selenium
     def test_beta_feedback_search_without_locale_redirects_to_feedback_search_with_locale(self, testsetup):
-        self._check_redirect(testsetup, '/beta/search?sentiment=sad', '/en-US/search?sentiment=sad')
+        self._check_redirect(testsetup, '/beta/?sentiment=sad', '/en-US/?sentiment=sad')
 
     @pytest.mark.skip_selenium
     def test_beta_feedback_search_with_locale_redirects_to_feedback_search_with_locale(self, testsetup):
-        self._check_redirect(testsetup, '/en-US/beta/search?sentiment=idea', '/en-US/search?sentiment=idea')
+        self._check_redirect(testsetup, '/en-US/beta/?sentiment=idea', '/en-US/?sentiment=idea')
 
     @pytest.mark.skip_selenium
     def test_release_feedback_search_without_locale_redirects_to_feedback_search_with_locale(self, testsetup):
-        self._check_redirect(testsetup, '/release/search?sentiment=happy', '/en-US/search?sentiment=happy')
+        self._check_redirect(testsetup, '/release/?sentiment=happy', '/en-US/?sentiment=happy')
 
     @pytest.mark.skip_selenium
     def test_release_feedback_search_with_locale_redirects_to_feedback_search_with_locale(self, testsetup):
-        self._check_redirect(testsetup, '/en-US/release/search?sentiment=sad', '/en-US/search?sentiment=sad')
+        self._check_redirect(testsetup, '/en-US/release/?sentiment=sad', '/en-US/?sentiment=sad')
 
     @pytest.mark.skip_selenium
     def test_themes_without_locale_redirects_to_themes_with_locale(self, testsetup):


### PR DESCRIPTION
Removed Xfails for bugs:
Bug 663862 - [stage] Landing page is missing components
Bug 662113 - Page does not update when selecting mobile in the product combobox

Removed the "search" term from redirects
