### PR TITLE
I proffer an xfail with the appropriate bug while we track the real fix.

### DIFF
--- a/test_date_filter.py
+++ b/test_date_filter.py
@@ -229,6 +229,7 @@ class TestSearchDates:
         feedback_pg.date_filter.click_custom_dates()
         Assert.equal(feedback_pg.date_filter.custom_start_date, start_date)
         Assert.equal(feedback_pg.date_filter.custom_end_date, end_date)
+        
     xfail(reason="Bug 686850 - Returned message counts vary too much to reliably test")
     def test_feedback_custom_date_filter_with_future_end_date(self, mozwebqa):
         """


### PR DESCRIPTION
See bug 686850; while we track the real fix (either staging server, increasing the accepted range, etc.), we shouldn't (IMHO) take the testsuite-failing hit for this.
