### PR TITLE
Bump Firefox version to 7.0, from 6.0

### DIFF
--- a/test_feedback_layout.py
+++ b/test_feedback_layout.py
@@ -104,7 +104,7 @@ class Test_Feedback_Layout:
         feedback_pg = feedback_page.FeedbackPage(mozwebqa)
         feedback_pg.go_to_feedback_page()
 
-        Assert.true(feedback_pg.product_filter.default_values("firefox", "6.0"))
+        Assert.true(feedback_pg.product_filter.default_values("firefox", "7.0"))
         Assert.false(feedback_pg.date_filter.is_date_filter_applied)
 
         Assert.false(feedback_pg.date_filter.is_custom_date_filter_visible)


### PR DESCRIPTION
Fixes this:

_______________ Test_Feedback_Layout.test_the_left_panel_layout ________________
[gw4] darwin -- Python 2.6.1 /Users/webqa/.jenkins/jobs/input.stage/workspace/.env/bin/python
self = <test_feedback_layout.Test_Feedback_Layout instance at 0x1031ea5a8>
mozwebqa = <mozwebqa.mozwebqa.TestSetup instance at 0x1031ea878>

```
def test_the_left_panel_layout(self, mozwebqa):
    """
        Litmus 13595 - input:Verify the layout of the left hand side section containing various
        filtering options
        Litmus 13600 - input:Verify the applications drop down in Product
        """

    feedback_pg = feedback_page.FeedbackPage(mozwebqa)
    feedback_pg.go_to_feedback_page()
```

> ```
>   Assert.true(feedback_pg.product_filter.default_values("firefox", "6.0"))
> ```

test_feedback_layout.py:107: 

---

self = <class unittestzero.Assert at 0x1035c6410>, first = False, msg = None

```
@classmethod
def true(self, first, msg=None):
```

> ```
>   assert first is True, msg
> ```
> 
> E       assert False is True
