### PR TITLE
Use requests instead of urllib/urllib2 for redirect tests.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,4 +2,5 @@ selenium
 pytest==2.1.3
 pytest-xdist==1.6
 pytest-mozwebqa
+requests==0.9.1
 unittestzero

--- a/tests/desktop/test_redirects.py
+++ b/tests/desktop/test_redirects.py
@@ -37,10 +37,9 @@
 #
 # ***** END LICENSE BLOCK *****
 
-import urllib2
-
 from unittestzero import Assert
 import pytest
+import requests
 
 
 class TestRedirects:
@@ -55,13 +54,10 @@ class TestRedirects:
             testsetup.selenium.get(start_url)
             Assert.equal(testsetup.selenium.current_url, end_url)
         else:
-            request = urllib2.Request(start_url)
-            opener = urllib2.build_opener()
-            request.add_header('User-Agent', user_agent)
-            request.add_header('Accept-Language', locale)
-            f = opener.open(request)
-            opener.close()
-            Assert.equal(f.url, end_url)
+            headers = {'user-agent': user_agent,
+                       'accept-language': locale}
+            r = requests.get(start_url, headers=headers)
+            Assert.equal(r.url, end_url)
 
     @pytest.mark.skip_selenium
     @pytest.mark.nondestructive


### PR DESCRIPTION
Inspired by the recent pull to move from urllib/urllib2 for redirect tests, I wanted to see if it would be possible to replace our Selenium redirect tests with requests.

Unfortunately due to the way these redirects work it's not possible, however the API for requests is much nicer so thought I'd submit a pull request anyway.
