### PR TITLE
Make all page objects return correct int data type

### DIFF
--- a/pages/base.py
+++ b/pages/base.py
@@ -114,7 +114,7 @@ class BasePage(Page):
     @property
     def page_from_url(self):
         """Returns the page value from the current location URL."""
-        return self._value_from_url("page")
+        return int(self._value_from_url("page"))
 
     @property
     def locale_from_url(self):

--- a/pages/desktop/feedback.py
+++ b/pages/desktop/feedback.py
@@ -84,7 +84,7 @@ class FeedbackPage(BasePage):
 
     @property
     def total_message_count(self):
-        return self.selenium.find_element(*self._total_message_count_locator).text
+        return int(self.selenium.find_element(*self._total_message_count_locator).text.replace(',',''))
 
     @property
     def total_message_count_heading(self):

--- a/pages/desktop/regions/locale_filter.py
+++ b/pages/desktop/regions/locale_filter.py
@@ -18,7 +18,7 @@ class LocaleFilter(Page):
 
     @property
     def total_message_count(self):
-        return self.selenium.find_element(*self._total_message_count_locator).get_attribute('data-total')
+        return int(self.selenium.find_element(*self._total_message_count_locator).get_attribute('data-total'))
 
     @property
     def are_more_locales_visible(self):
@@ -67,11 +67,11 @@ class LocaleFilter(Page):
         def message_count(self):
             # TODO Use native mouse interactions to hover over element to get the text
             message_count = self._root_element.find_element(*self._message_count_locator)
-            return self.selenium.execute_script('return arguments[0].textContent', message_count)
+            return int(self.selenium.execute_script('return arguments[0].textContent', message_count))
 
         @property
         def message_percentage(self):
-            return self._root_element.find_element(*self._message_percentage_locator).text
+            return int(self._root_element.find_element(*self._message_percentage_locator).text.split("%")[0])
 
         def select(self):
             self._root_element.find_element(*self._checkbox_locator).click()

--- a/pages/desktop/regions/platform_filter.py
+++ b/pages/desktop/regions/platform_filter.py
@@ -51,7 +51,7 @@ class PlatformFilter(Page):
             def message_count(self):
                 # TODO Use native mouse interactions to hover over element to get the text
                 message_count = self._root_element.find_element(*self._message_count_locator)
-                return self.selenium.execute_script('return arguments[0].textContent', message_count)
+                return int(self.selenium.execute_script('return arguments[0].textContent', message_count))
 
             def click(self):
                 self._root_element.find_element(*self._checkbox_locator).click()

--- a/tests/desktop/test_locale_filter.py
+++ b/tests/desktop/test_locale_filter.py
@@ -34,7 +34,7 @@ class TestLocaleFilter:
         locale_code = locale.code
         locale.select()
 
-        Assert.equal(feedback_pg.total_message_count.replace(',', ''), locale_message_count)
+        Assert.equal(feedback_pg.total_message_count, locale_message_count)
         Assert.equal(feedback_pg.locale_from_url, locale_code)
         [Assert.equal(message.locale, locale_name) for message in feedback_pg.messages]
 
@@ -67,7 +67,7 @@ class TestLocaleFilter:
         locale_code = locale.code
         locale.select()
 
-        Assert.equal(feedback_pg.total_message_count.replace(',', ''), locale_message_count)
+        Assert.equal(feedback_pg.total_message_count, locale_message_count)
         Assert.equal(feedback_pg.locale_from_url, locale_code)
         [Assert.equal(message.locale, locale_name) for message in feedback_pg.messages]
 
@@ -80,4 +80,4 @@ class TestLocaleFilter:
         feedback_pg.locale_filter.show_more_locales()
         for locale in feedback_pg.locale_filter.locales:
             expected_percentage = round((float(locale.message_count) / float(feedback_pg.locale_filter.total_message_count)) * 100)
-            Assert.equal(expected_percentage, int(locale.message_percentage.split("%")[0]))
+            Assert.equal(expected_percentage, locale.message_percentage)

--- a/tests/desktop/test_pagination.py
+++ b/tests/desktop/test_pagination.py
@@ -61,7 +61,7 @@ class TestPagination:
         Assert.equal(feedback_pg.older_messages_link, u"\xab Older Messages")
         Assert.equal(feedback_pg.newer_messages_link, u"Newer Messages \xbb")
 
-        Assert.equal(int(feedback_pg.page_from_url), 2)
+        Assert.equal(feedback_pg.page_from_url, 2)
 
         feedback_pg.click_newer_messages()
         Assert.equal(feedback_pg.product_from_url, "firefox")
@@ -76,4 +76,4 @@ class TestPagination:
         Assert.equal(feedback_pg.older_messages_link, u"\xab Older Messages")
         Assert.equal(feedback_pg.newer_messages_link, u"Newer Messages \xbb")
 
-        Assert.equal(int(feedback_pg.page_from_url), 1)
+        Assert.equal(feedback_pg.page_from_url, 1)

--- a/tests/desktop/test_platform_filter.py
+++ b/tests/desktop/test_platform_filter.py
@@ -34,8 +34,8 @@ class TestPlatformFilter:
         platform_code = platform.code
         platform.click()
 
-        total_message_count = feedback_pg.total_message_count.replace(',', '')
-        message_count_difference = int(total_message_count) - int(platform_message_count)
+        total_message_count = feedback_pg.total_message_count
+        message_count_difference = total_message_count - platform_message_count
 
         Assert.equal(len(feedback_pg.platform_filter.platforms), 1)
         Assert.true(feedback_pg.platform_filter.platform(platform_name).is_selected)


### PR DESCRIPTION
Declutters the test and makes the PO return the data type that the name suggests (ie count returns int).
