### PR TITLE
Fix for intermittent failure on input.prod related to sliding page

### DIFF
--- a/pages/desktop/submit_feedback.py
+++ b/pages/desktop/submit_feedback.py
@@ -36,7 +36,7 @@ class SubmitFeedbackPage(BasePage):
         self.selenium.find_element(*self._support_page_locator).click()
 
     def wait_for_page_to_slide_into_view(self, page_locator):
-        WebDriverWait(self.selenium, self.timeout).until(lambda s: 'entering' in s.find_element(*page_locator).get_attribute('class'))
+        WebDriverWait(self.selenium, self.timeout).until(lambda s: self.is_element_visible(page_locator))
         WebDriverWait(self.selenium, self.timeout).until(lambda s: 'entering' not in s.find_element(*page_locator).get_attribute('class'))
 
     def click_happy_feedback(self):


### PR DESCRIPTION
There is an intermittent failure on input.prod which is related to waiting for the sliding page to transition. The test seems to always fail when waiting for the "entering" class to appear on an element. The test was waiting for this class to appear and then disappear. I am guessing that perhaps the class is appearing and disappearing so quickly that sometimes the wait doesn't catch the appearance. I have changed the logic not to look for the appearance of the "entering" class, but rather to wait for the panel to be visible and also for the entering class to be gone. This seems to work in my test runs, so I suggest we see if it solves the intermittent failure.
