### PR TITLE
Update test_locale_filter.py

### DIFF
--- a/pages/desktop/regions/locale_filter.py
+++ b/pages/desktop/regions/locale_filter.py
@@ -11,21 +11,36 @@ from pages.base import Page
 
 class LocaleFilter(Page):
 
+    _locales_checkbox_locator = (By.CSS_SELECTOR, ".bars[name='locale'] input")
     _locales_locator = (By.CSS_SELECTOR, "ul[name='locale'] li")
-    _more_locales_link_locator = (By.CSS_SELECTOR, '#filter_locale .more')
-    _more_locales_locator = (By.CSS_SELECTOR, '#filter_locale .extra li')
-    _total_message_count_locator = (By.CSS_SELECTOR, '#filter_locale .bars')
 
     @property
-    def total_message_count(self):
-        return int(self.selenium.find_element(*self._total_message_count_locator).get_attribute('data-total'))
+    def locales(self):
+        """Returns a list of Locale instances"""
+        locales = [self.Locale(self.testsetup, element) for element in self.selenium.find_elements(*self._locales_locator)]
+        return locales
 
     @property
-    def are_more_locales_visible(self):
-        return self.is_element_visible(self._more_locales_locator)
+    def selected_locale(self):
+        """Returns the currently selected locale."""
+        for locale in self.locales:
+            if locale.is_selected:
+                return locale
 
-    def show_more_locales(self):
-        self.selenium.find_element(*self._more_locales_link_locator).click()
+    def select_locale(self, value):
+        """Selects a locale."""
+        select = self.selenium.find_element(
+            self._locales_checkbox_locator[0],
+            self._locales_checkbox_locator[1] + '[value="%s"]' % value)
+        if not select.is_selected():
+            select.click()
+
+    def unselect_locale(self, value):
+        select = self.selenium.find_element(
+            self._locales_checkbox_locator[0],
+            self._locales_checkbox_locator[1] + '[value="%s"]' % value)
+        if select.is_selected():
+            select.click()
 
     def locale(self, value):
         for locale in self.locales:
@@ -33,12 +48,6 @@ class LocaleFilter(Page):
                 return locale
         raise Exception("Locale not found: '%s'. Locales: %s" % (value, [locale.name for locale in self.locales]))
 
-    @property
-    def locales(self):
-        locales = [self.Locale(self.testsetup, element) for element in self.selenium.find_elements(*self._locales_locator)]
-        if self.are_more_locales_visible:
-            locales.extend([self.Locale(self.testsetup, element) for element in self.selenium.find_elements(*self._more_locales_locator)])
-        return locales
 
     class Locale(Page):
 

--- a/pages/desktop/regions/message.py
+++ b/pages/desktop/regions/message.py
@@ -15,7 +15,7 @@ class Message(Page):
     _body_locator = (By.CSS_SELECTOR, '.body')
     _time_locator = (By.CSS_SELECTOR, 'time')
     _platform_locator = (By.CSS_SELECTOR, '.meta li:nth-child(2) a')
-    _locale_locator = (By.CSS_SELECTOR, '.meta li:nth-child(3) a')
+    _locale_locator = (By.CSS_SELECTOR, '.meta li:nth-child(4) a')
     _site_locator = (By.CSS_SELECTOR, '.meta li:nth-child(4)')
     _more_options_locator = (By.CSS_SELECTOR, '.options')
     _copy_user_agent_locator = (By.CSS_SELECTOR, '.options .copy_ua')

--- a/tests/desktop/test_locale_filter.py
+++ b/tests/desktop/test_locale_filter.py
@@ -4,71 +4,51 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-from unittestzero import Assert
 import pytest
+from unittestzero import Assert
 
 from pages.desktop.feedback import FeedbackPage
 
 
-class TestLocaleFilter:
+class TestLocaleFilter(object):
 
     @pytest.mark.nondestructive
     def test_feedback_can_be_filtered_by_locale(self, mozwebqa):
         """This testcase covers # 15120 in Litmus.
 
-        1. Verify that the number of messages in the locale list matches the number of messages returned
-        2. Verify that the locale short code appears in the URL
-        3. Verify that the locale for all messages on the first page of results is correct
+        1. Verify we see at least one locale
+        2. Select that locale
+        3. Verify number of messages in locale is less than total number of messages
+        4. Verify locale short code appears in the URL
+        5. Verify that the locale for all messages on the first page of results is correct
 
         """
         feedback_pg = FeedbackPage(mozwebqa)
 
         feedback_pg.go_to_feedback_page()
-        feedback_pg.product_filter.select_product('firefox')
+        total_messages = feedback_pg.total_message_count
 
-        locale_name = "Russian"
-        locale = feedback_pg.locale_filter.locale(locale_name)
-        locale_message_count = locale.message_count
-        locale_code = locale.code
-        locale.select()
+        locales = feedback_pg.locale_filter.locales
+        locale_names = [locale.name for locale in locales]
 
-        Assert.equal(feedback_pg.total_message_count, locale_message_count)
-        Assert.equal(feedback_pg.locale_from_url, locale_code)
-        [Assert.equal(message.locale, locale_name) for message in feedback_pg.messages]
+        Assert.greater_equal(len(locales), 1)
 
-    @pytest.mark.xfail(reason='Bug 940361 - response counts for a locale in sidebar change when you select the locale')
-    @pytest.mark.skipif("not config.getvalue('base_url').endswith('allizom.org')")
-    @pytest.mark.nondestructive
-    def test_feedback_can_be_filtered_by_locale_from_expanded_list(self, mozwebqa):
-        """This testcase covers # 15087 & 15120 in Litmus.
+        for name in locale_names[:2]:
+            locale = feedback_pg.locale_filter.locale(name)
 
-        1. Verify the initial locale count is 10
-        2. Verify clicking the more locales link shows additional locales
-        3. Verify filtering by one of the additional locales
-        4. Verify that the number of messages in the locale list matches the number of messages returned
-        5. Verify that the locale short code appears in the URL
-        6. Verify that the locale for all messages on the first page of results is correct
-
-        """
-        feedback_pg = FeedbackPage(mozwebqa)
-
-        feedback_pg.go_to_feedback_page()
-        feedback_pg.product_filter.select_product('firefox')
-
-        Assert.equal(len(feedback_pg.locale_filter.locales), 10)
-
-        locale_names = []
-        for locale in feedback_pg.locale_filter.locales:
-            locale_names.append(locale.name)
-        for locale_name in locale_names:
-            locale = feedback_pg.locale_filter.locale(locale_name)
-            locale_message_count = locale.message_count
+            locale_name = locale.name
             locale_code = locale.code
-            locale.select()
-            Assert.equal(feedback_pg.total_message_count, locale_message_count)
-            Assert.equal(feedback_pg.locale_from_url, locale_code)
-            [Assert.equal(message.locale, locale_name) for message in feedback_pg.messages]
+            locale_count = locale.message_count
+            Assert.greater(total_messages, locale_count)
 
-            # Un-select selected locale
-            locale = feedback_pg.locale_filter.locale(locale_name)
-            locale.select()
+            feedback_pg.locale_filter.select_locale(locale_code)
+
+            Assert.greater(total_messages, feedback_pg.total_message_count)
+            Assert.equal(len(feedback_pg.locale_filter.locales), 1)
+            Assert.equal(feedback_pg.locale_filter.selected_locale.name, locale_name)
+            Assert.equal(feedback_pg.locale_from_url, locale_code)
+
+            for message in feedback_pg.messages:
+                Assert.equal(message.locale, locale_name)
+
+            feedback_pg.locale_filter.unselect_locale(locale_code)


### PR DESCRIPTION
Fixes the test that makes sure filtering by locale works.

This nixes a test that was marked as xfail. I'm not sure it's that
interesting a test because I'm not sure we really care whether the two
numbers are almost the same. Plus since it's tickling bug #940361 in
Input which I'm not planning to fix anytime soon, I think we should just
rewrite it when the bug is fixed and thus carry less technical debt.

Fixes #147

r?
